### PR TITLE
Make installable with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Install **ng-inline-edit** via [Bower](http://bower.io):
 ```bash
 bower install ng-inline-edit --production
 ```
+or
+```bash
+npm install ng-inline-edit --save
+```
 
 Include main files:
 ```html
@@ -21,6 +25,15 @@ angular
   .module('yourApp', [
     'angularInlineEdit'
   ]);
+```
+
+Or when you're using Webpack and installed via npm, skip the script tag and
+
+```js
+import ngInlineEdit from 'ng-inline-edit'
+import 'ng-inline-edit/dist/ng-inline-edit.css'
+
+angular.module('myApp', [ngInlineEdit])
 ```
 
 Pass your model to ``inline-edit`` attribute on your HTML element and provide a callback function to listen changes:

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/ng-inline-edit');
+module.exports = 'angularInlineEdit';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-inline-edit",
   "description": "Simple inline editing for HTML elements",
   "version": "0.7.0",
-  "main": "dist/ng-inline-edit.js",
+  "main": "index.js",
   "keywords": [
     "angular",
     "component",


### PR DESCRIPTION
This change is required to allow ng-inline-edit to be importable with es6 and bundled with webpack and AngularJS 1.x. Without the change, this is the error that occurs when running the angular app.

```
Uncaught Error: [$injector:modulerr] Failed to instantiate module nprc-portal due to:
Error: [$injector:modulerr] Failed to instantiate module {} due to:
Error: [ng:areq] Argument 'module' is not a function, got Object
```

Btw, the tests were already failing before my changes on my local machine due to some PhantomJS problem and a requirement for an older Node.js version.