### PR TITLE
Allow displaying values such as false, "false" etc

### DIFF
--- a/src/scripts/directives.js
+++ b/src/scripts/directives.js
@@ -52,7 +52,7 @@
                 'ng-class="{\'ng-inline-edit__text--placeholder\': !model}" ' +
                 (attrs.hasOwnProperty('inlineEditOnClick') || InlineEditConfig.editOnClick ?
                   'ng-click="editText()" ' : '') +
-                'ng-if="!editMode">{{(model || placeholder)' +
+                'ng-if="!editMode">{{(model !== null && model !== undefined ? model : placeholder)' +
                   (attrs.hasOwnProperty('inlineEditFilter') ? ' | ' + attrs.inlineEditFilter : '') +
                   '}}</span>'));
 


### PR DESCRIPTION
Checks explicitly if the value is either `null` or `undefined` to allow for other "falsy" values such as `false`, "false" etc.